### PR TITLE
Simple implementation of listenTo and stopListening using addListener and removeListener

### DIFF
--- a/examples/listen-to.html
+++ b/examples/listen-to.html
@@ -1,0 +1,137 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Rye listen to</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+    <style type="text/css">
+        section {
+            width: 200px;
+            padding: 20px;
+            display: inline-block;
+            vertical-align: top;
+            border: 1px solid #000;
+        }
+    </style>
+</head>
+<body>
+    <button class="trigger">Trigger event listeners</button>
+    <button class="clear">Clear event count</button>
+    <section id="classic">
+        <button class="add-classic">Add a classic event listener</button>
+
+        <div>Total triggered: <span class="result result-classic">0</span></div>
+
+        <ul class="list list-classic">
+
+        </ul>
+    </section>
+    <section id="listenTo">
+        <button class="add-listenTo">Add a listenTo event listener</button>
+
+        <div>Total triggered: <span class="result result-listenTo">0</span></div>
+
+        <ul class="list list-listenTo">
+        </ul>
+
+    </section>
+
+    <script src="../dist/rye.js"></script>
+    <script>
+        /**
+         * listen to test
+         */
+
+        window.$ = Rye;
+
+        var EventEmitter = $.require('Events').EventEmitter,
+            util = $.require('Util'),
+            target = new EventEmitter,
+            views = {},
+            App = new EventEmitter;
+
+        $('.add-classic, .add-listenTo').on('click', function () {
+
+            var type = ($(this).hasClass('add-classic')) ? 'classic' : 'listenTo';
+
+            var id = util.getUid('j');
+            views[id] = new View(type, id);
+            views[id].init();
+            // console.log(views);
+        })
+
+
+        //view
+        $('body').on('click .remove-this', function () {
+            var id = $(this).parent().attr('id');
+            views[id].emitter.stopListening();
+            delete views[id];
+            $(this).parent().remove();
+        })
+
+        function View (htmlId, id) {
+
+            this.emitter = new EventEmitter;
+
+            this.init = function () {
+                var tpl = {
+                        'classic': '<li id="' + id + '">classic<button class="remove-this">-</button></li>',
+                        'listenTo': '<li id="' + id + '">listenTo<button class="remove-this">-</button></li>'
+                    },
+                    events = {
+                        'classic': 'classic',
+                        'listenTo': 'listen'
+                    },
+                    frag = document.createDocumentFragment();
+
+
+                frag.innerHTML = tpl[htmlId];
+
+                this[events[htmlId]]();
+
+                $('#' + htmlId + ' .list').append(frag.innerHTML);
+            }
+
+            this.classic = function () {
+                App.on('custom:event', function () {
+                    var result = $('#' + htmlId + ' .result-' + htmlId),
+                        count = parseInt(result.html(), 10);
+
+                    result.html(++count);
+                });
+            }
+
+            this.listen = function () {
+                this.emitter.listenTo(App, 'custom:event', function () {
+                    var result = $('#' + htmlId + ' .result-' + htmlId),
+                        count = parseInt(result.html(), 10);
+
+                    result.html(++count);
+                });
+
+                this.emitter.listenTo(App, 'custom:event1', function () {
+                    console.log('event1');
+                });
+                this.emitter.listenTo(App, 'custom:event2', function () {
+                    console.log('event2');
+                });
+            }
+
+            return this;
+
+        }
+
+        //event
+        $('body').on('click .trigger', function () {
+            App.emit('custom:event');
+            App.emit('custom:event1');
+            App.emit('custom:event2');
+        })
+
+        $('body').on('click .clear', function () {
+            $('.result').html(0)
+        })
+
+    </script>
+</body>
+</html>

--- a/lib/events.js
+++ b/lib/events.js
@@ -70,6 +70,79 @@ Rye.define('Events', function(){
         return util.applyLeft(this, this.emit, [event])
     }
 
+    // Reverse implementation to keep track of all events and be able to remove them allowing GC to work
+    EventEmitter.prototype.listenTo = function (target, event, handler) {
+
+        var listeners = this.listeners || (this.listeners = {})
+          , uId = target._listenerId || (target._listenerId = util.getUid('u')) //when removing this object, this will be required
+
+        if (!listeners[uId]) {
+            listeners[uId] = {
+                target: target,
+                handlers: []
+            }
+        }
+
+        listeners[uId].handlers.push({
+            event: event,
+            callback: handler
+        })
+
+        target.addListener(event, handler)
+
+        return this
+    }
+
+    // Reverse implementation to keep track of all events and be able to remove them allowing GC to work
+    EventEmitter.prototype.stopListening = function (target, event, handler) {
+
+        var deleteAllEvents = false
+          , listeners = this.listeners
+
+        if (!listeners) {
+            return this
+        }
+
+        if (!target && !event && !handler) {
+            deleteAllEvents = true
+        }
+
+        var listenersIds = Object.keys(listeners);
+
+        util.each(listenersIds, function (id) {
+
+            var thisId = listeners[id],
+                removeHandlersList = []
+
+            if (!target || target == thisId.target) {
+                //find all handlers that should be removed
+                util.each(thisId.handlers, function (thisHandler, index) {
+                    if (!handler || handler == thisHandler.callback) {
+                        removeHandlersList.push(index)
+                    }
+                })
+
+                //remove handlers
+                var handlerIndex = removeHandlersList.length;
+
+                while (handlerIndex--) {
+                    var thisHandler = thisId.handlers[handlerIndex]
+
+                    thisId.target.removeListener(thisHandler.event, thisHandler.callback)
+                    thisId.handlers.splice(handlerIndex, 1)
+                }
+            }
+
+            if (deleteAllEvents || thisId.handlers.length < 1) {
+                delete listeners[id]
+            }
+
+        });
+
+        return this
+    }
+
+
     // Utility methods
     // -----------------------------
 
@@ -109,7 +182,7 @@ Rye.define('Events', function(){
     /*
         Creates one event emitter per element, proxies DOM events to it. This way
         we can keep track of the functions so that they can be removed from the
-        elements by reference when you call .removeListener() by event name.   
+        elements by reference when you call .removeListener() by event name.
     */
 
     function DOMEventEmitter (element) {
@@ -206,7 +279,7 @@ Rye.define('Events', function(){
 
     // Exported methods
     // -----------------------------
-    
+
     var exports = {}
 
     function emitterProxy (method, element, event, handler) {
@@ -223,7 +296,7 @@ Rye.define('Events', function(){
 
     // Aliases
     // -----------------------------
-    
+
     ;[EventEmitter.prototype, DOMEventEmitter.prototype, this].forEach(function(obj){
         obj.on = obj.addListener
     })
@@ -237,7 +310,7 @@ Rye.define('Events', function(){
     Rye.unsubscribe = EE.removeListener.bind(EE)
     Rye.publish     = EE.emit.bind(EE)
 
-    
+
     return {
         EventEmitter    : EventEmitter
       , DOMEventEmitter : DOMEventEmitter

--- a/test/events.spec.coffee
+++ b/test/events.spec.coffee
@@ -17,7 +17,7 @@ suite 'EventEmitter', ->
         x.on 'click', fn
         x.removeListener 'click'
         assert x.events['click'] is undefined, "Event removed by name"
-    
+
     test 'remove all listener', ->
         x = new EventEmitter
         fn = -> 123
@@ -45,10 +45,42 @@ suite 'EventEmitter', ->
             assert arg is 4, "Argument received"
         x.emit 'click', 4
         x.emit 'click', 5
-        
+
         setTimeout ->
             assert x.events['click'] is undefined, "Event removed"
             done()
+
+suite 'ListenTo', ->
+
+    test 'add listenTo', ->
+        emitter1 = new EventEmitter
+        emitter2 = new EventEmitter
+        emitter2.listenTo emitter1, 'click', -> null
+        assert.equal emitter1.events['click'].length, 1
+
+    test 'stop listenTo', ->
+        x = new EventEmitter
+        y = new EventEmitter
+        fn = -> 123
+
+        y.listenTo x, 'click', fn
+        y.stopListening x, 'click', fn
+        assert x.events['click'] is undefined, "Event removed by reference"
+
+        y.listenTo x, 'click', fn
+        y.stopListening x, 'click'
+        assert x.events['click'] is undefined, "Event removed by name"
+
+
+    test 'remove all listenTo', ->
+        x = new EventEmitter
+        y = new EventEmitter
+        fn = -> 123
+
+        y.listenTo x, 'click', fn
+        y.listenTo x, 'keydown', fn
+        y.stopListening()
+        assert x.events['click'] is undefined, "Event removed by reference"
 
 suite 'PubSub', ->
 
@@ -127,8 +159,8 @@ suite 'DOMEvents', ->
         events.addListener el, 'blur li', do_not_call
         events.addListener el, 'focus li', do_not_call
         events.removeListener el, 'click ul'
-        events.removeListener el, 'blur *' 
-        events.removeListener el, 'focus*' 
+        events.removeListener el, 'blur *'
+        events.removeListener el, 'focus*'
 
         events.trigger item, 'click'
         events.trigger item, 'blur'


### PR DESCRIPTION
When using listenTo it will keep track of all the handlers on every other EventEmitter object. When stopListening is called, it is possible to remove all handlers and then the events will not stop the object from being captured by garbage collector
