### PR TITLE
Improved getting of matchesSelector method

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -10,9 +10,10 @@ Rye.define('Query', function(){
           , '_': 'querySelectorAll'
         }
       , dummyDiv = document.createElement('div')
+      , matchesSelector
 
     function matches(element, selector) {
-        var matchesSelector, match
+        var match
         if (!element || !util.isElement(element) || !selector) {
             return false
         }
@@ -31,7 +32,7 @@ Rye.define('Query', function(){
             return false
         }
 
-        matchesSelector = util.prefix('matchesSelector', dummyDiv)
+        matchesSelector = matchesSelector || (matchesSelector = element.matches || util.prefix('matchesSelector', dummyDiv))
         if (matchesSelector) {
             return matchesSelector.call(element, selector)
         }

--- a/lib/query.js
+++ b/lib/query.js
@@ -9,7 +9,6 @@ Rye.define('Query', function(){
           , '' : 'getElementsByTagName'
           , '_': 'querySelectorAll'
         }
-      , dummyDiv = document.createElement('div')
       , matchesSelector
 
     function matches(element, selector) {
@@ -32,7 +31,7 @@ Rye.define('Query', function(){
             return false
         }
 
-        matchesSelector = matchesSelector || (matchesSelector = element.matches || util.prefix('matchesSelector', dummyDiv))
+        matchesSelector = matchesSelector || (matchesSelector = element.matches || util.prefix('matchesSelector', element))
         if (matchesSelector) {
             return matchesSelector.call(element, selector)
         }


### PR DESCRIPTION
1. caches the prefixed method after the first time it is fetched
2. uses the standards compliant `matches` method where available
3. gets rid of the superfluous dummyDiv