### PR TITLE
Add removeAttr to element manipulation

### DIFF
--- a/lib/manipulation.js
+++ b/lib/manipulation.js
@@ -159,6 +159,12 @@ Rye.define('Manipulation', function(){
             })
     }
 
+    this.removeAttr = function (name) {
+        return this.each(function(element) {
+            element.removeAttribute(name)
+        })
+    }
+
     this.prop = function (name, value) {
         if (typeof name === 'object'){
             return this.each(function(element){

--- a/test/manipulation.spec.coffee
+++ b/test/manipulation.spec.coffee
@@ -246,6 +246,15 @@ suite 'Manipulation', ->
         el.attr 'title': ''
         assert.equal input.getAttribute('title'), ''
 
+    test 'remove attr', ->
+        input = document.createElement('input')
+        el = $(input)
+        el.attr('disabled', 'disabled')
+        assert.isTrue input.disabled
+
+        el.removeAttr 'disabled'
+        assert.isFalse input.disabled
+
     test 'get prop', ->
         input = document.createElement('input')
         input.title = 'title'


### PR DESCRIPTION
Added missing feature `.removeAttr`, same spec as jQuerie's `.removeAttr`.