### PR TITLE
Package Rye for both global and CommonJS usage

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+examples
+test

--- a/Cakefile
+++ b/Cakefile
@@ -40,6 +40,11 @@ sources_full = sources_base.concat [
     'lib/request.js'
 ]
 
+dist_bundle_options = {
+    before: '(function(global){',
+    after: """; if (typeof module !== 'undefined') { module.exports = Rye } else { global.Rye = Rye } })(typeof window !== 'undefined' ? window : {})"""
+}
+
 option '-l', '--light', 'Light version'
 
 getSources = (o) ->
@@ -55,13 +60,13 @@ getDist = (o, min) ->
 async task 'build:prod', (o, done) ->
     try fs.mkdirSync 'dist'
     flour.minifiers.enable 'js'
-    bundle getSources(o), getDist(o, true), ->
+    bundle getSources(o), dist_bundle_options, getDist(o, true), (output, file) ->
         flour.minifiers.disable 'js'
         done()
 
 async task 'build:dev', (o, done) ->
     try fs.mkdirSync 'dist'
-    bundle getSources(o), getDist(o), done
+    bundle getSources(o), dist_bundle_options, getDist(o), done
 
 async task 'build:test', (o, done) ->
     bundle 'test/*.coffee', 'test/spec.js', done

--- a/lib/rye.js
+++ b/lib/rye.js
@@ -1,48 +1,43 @@
-(function(global){
-
-    function Rye (selector, context) {
-        if (!(this instanceof Rye)){
-            return new Rye(selector, context)
-        }
-
-        if (selector instanceof Rye){
-            return selector
-        }
-
-        var util = Rye.require('Util')
-
-        if (typeof selector === 'string') {
-            this.selector = selector
-            this.elements = this.qsa(context, selector)
-
-        } else if (selector instanceof Array) {
-            this.elements = util.unique(selector.filter(util.isElement))
-
-        } else if (util.isNodeList(selector)) {
-            this.elements = Array.prototype.slice.call(selector).filter(util.isElement)
-
-        } else if (util.isElement(selector)) {
-            this.elements = [selector]
-
-        } else {
-            this.elements = []
-        }
-
-        this._update()
+function Rye (selector, context) {
+    if (!(this instanceof Rye)){
+        return new Rye(selector, context)
     }
 
-    Rye.version = '0.1.0'
-
-    // Minimalist module system
-    var modules = {}
-    Rye.require = function (module) {
-        return modules[module]
-    }
-    Rye.define = function (module, fn) {
-        modules[module] = fn.call(Rye.prototype)
+    if (selector instanceof Rye){
+        return selector
     }
 
-    // Export global object
-    global.Rye = Rye
+    var util = Rye.require('Util')
 
-})(window)
+    if (typeof selector === 'string') {
+        this.selector = selector
+        this.elements = this.qsa(context, selector)
+
+    } else if (selector instanceof Array) {
+        this.elements = util.unique(selector.filter(util.isElement))
+
+    } else if (util.isNodeList(selector)) {
+        this.elements = Array.prototype.slice.call(selector).filter(util.isElement)
+
+    } else if (util.isElement(selector)) {
+        this.elements = [selector]
+
+    } else {
+        this.elements = []
+    }
+
+    this._update()
+}
+
+Rye.version = '0.1.0'
+
+// Minimalist module system
+Rye._modules = {}
+
+Rye.require = function (module) {
+    return Rye._modules[module]
+}
+
+Rye.define = function (module, fn) {
+    Rye._modules[module] = fn.call(Rye.prototype)
+}

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-    "name": "rye",
+    "name": "ryejs",
     "description": "A lightweight browser library",
     "version": "0.1.0",
-    "main": "lib/rye.js",
+    "main": "dist/rye.js",
     "dependencies": {
     },
     "devDependencies": {
@@ -14,6 +14,7 @@
         "coffee-script": "~1"
     },
     "scripts": {
+        "prepublish": "cake build:dev",
         "test": "cake -b PhantomJS test lint"
     },
     "repository": {


### PR DESCRIPTION
This commit:
- Changes distribution bundles on `Cakefile` to add the wrapper for switching exporting on global `window` or `module.exports`, running everything on one properly isolated scope.
- Moves the declaration of `Rye` to the root scope, so that inner code can reference it if it's not in the global scope (e.g. `new Rye`).
- Adds a `prepublish` npm script that runs `cake build:dev`, so that the distribution file is available immediatelly after `npm install`, and also before publishing on npm.
- Renames the project to _ryejs_ on package.json because _rye_ has already been taken :(